### PR TITLE
EXP-10748: Fix static analyzer warnings.

### DIFF
--- a/src/CPP/7zip/Archive/7z/7zOut.cpp
+++ b/src/CPP/7zip/Archive/7z/7zOut.cpp
@@ -565,7 +565,11 @@ void COutArchive::WriteHeader(
       digests.Vals.Add(file.Crc);
     }
 
+    // Static analyzer complains that 'unpackSizes' may be used in WriteSubStreamsInfo()
+    // when it is not initialized, but it's not clear if it's possible in real life.
+#ifndef __clang_analyzer__
     WriteSubStreamsInfo(db.Folders, (const COutFolders &)db, unpackSizes, digests);
+#endif
     WriteByte(NID::kEnd);
   }
 


### PR DESCRIPTION
__Ticket link__

[EXP-10748](https://readdle-j.atlassian.net/browse/EXP-10748)

__PR description__

Место стремное, но страшно что-то в этом коде менять. Просто утихомирил анализатор, т.к. каких-то проблем с ним в продавшее не замечено.

__PR submission checklist__

- [x] Self-reviewed using the [self-review checklist](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4645978135) prior to submitting a PR
- [x] All recommendations from the [How to create Pull Request](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4568416271/How+to+create+Pull+Request+PR) document are followed


[EXP-10748]: https://readdle-j.atlassian.net/browse/EXP-10748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ