### PR TITLE
[skip ci] EXP-14633: Update the pull request template file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,11 @@ __PR submission checklist__
 - [ ] PR have correct target branch
 - [ ] .s7substat has correct subrepos revisions
 - [ ] Common ([Obj-C](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/3802038524/Common+Objective-C+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams) / [Swift](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4662394906/Common+Swift+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams)) and your team's coding conventions and style guidelines are followed
+- [ ] All new UI components meet accessibility expectations according to the [Accessibility guide](https://readdle-c.atlassian.net/wiki/spaces/RD2/pages/5595496478/Accessibility+guide).
 - [ ] Unit tests to cover the critical parts of the code are written
-- [ ] Relevant documentation updated / added if needed
+- [ ] Relevant documentation updated / added if needed [^1]
 - [ ] Self-reviewed using the [self-review checklist](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4645978135) prior to submitting a PR
 - [ ] All recommendations from the [How to create Pull Request](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4568416271/How+to+create+Pull+Request+PR) document are followed
+
+[^1]: List of documents we maintain up to date:
+    - [Accessibility Guide](https://readdle-c.atlassian.net/wiki/spaces/RD2/pages/5595496478/Accessibility+guide)


### PR DESCRIPTION
__Ticket link__

[EXP-14633](https://readdle-j.atlassian.net/browse/EXP-14633)

__PR description__

I'm adding a link to the Accessibility guide (and an accessibility-related checklist item) according to a retro item of Accessibility Improvements mission within the EXP team.

__PR submission checklist__

- [x] PR name contains Jira ticket number
- [x] PR have correct target branch
- [x] .s7substat has correct subrepos revisions
- [x] Common ([Obj-C](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/3802038524/Common+Objective-C+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams) / [Swift](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4662394906/Common+Swift+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams)) and your team's coding conventions and style guidelines are followed
- [x] All new UI components meet accessibility expectations according to the [Accessibility guide](https://readdle-c.atlassian.net/wiki/spaces/RD2/pages/5595496478/Accessibility+guide).
- [x] Unit tests to cover the critical parts of the code are written
- [x] Relevant documentation updated / added if needed [^1]
- [x] Self-reviewed using the [self-review checklist](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4645978135) prior to submitting a PR
- [x] All recommendations from the [How to create Pull Request](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4568416271/How+to+create+Pull+Request+PR) document are followed

[^1]: List of documents we maintain up to date:
    - [Accessibility Guide](https://readdle-c.atlassian.net/wiki/spaces/RD2/pages/5595496478/Accessibility+guide)


[EXP-14633]: https://readdle-j.atlassian.net/browse/EXP-14633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ