### PR TITLE
Merge main-pre-exp21130 (rd2-main) into main

### DIFF
--- a/src/CPP/7zip/Archive/7z/7zDecode.cpp
+++ b/src/CPP/7zip/Archive/7z/7zDecode.cpp
@@ -234,6 +234,8 @@ HRESULT CDecoder::Decode(
     #endif
     )
 {
+#ifndef __clang_analyzer__
+
   dataAfterEnd_Error = false;
 
   const UInt64 *packPositions = &folders.PackPositions[folders.FoStartPackStreamIndex[folderIndex]];
@@ -594,6 +596,9 @@ HRESULT CDecoder::Decode(
   #else
     return E_FAIL;
   #endif
+    
+#endif
+
 }
 
 }}

--- a/src/CPP/7zip/Archive/7z/7zExtract.cpp
+++ b/src/CPP/7zip/Archive/7z/7zExtract.cpp
@@ -229,6 +229,8 @@ Z7_COM7F_IMF(CFolderOutStream::GetSubStreamSize(UInt64 subStream, UInt64 *value)
 Z7_COM7F_IMF(CHandler::Extract(const UInt32 *indices, UInt32 numItems,
     Int32 testModeSpec, IArchiveExtractCallback *extractCallbackSpec))
 {
+#ifndef __clang_analyzer__
+
   // for GCC
   // CFolderOutStream *folderOutStream = new CFolderOutStream;
   // CMyComPtr<ISequentialOutStream> outStream(folderOutStream);
@@ -440,6 +442,8 @@ Z7_COM7F_IMF(CHandler::Extract(const UInt32 *indices, UInt32 numItems,
   return S_OK;
 
   COM_TRY_END
+    
+#endif
 }
 
 }}

--- a/src/CPP/7zip/Archive/LzmaHandler.cpp
+++ b/src/CPP/7zip/Archive/LzmaHandler.cpp
@@ -460,6 +460,8 @@ Z7_COM7F_IMF(CCompressProgressInfoImp::SetRatioInfo(const UInt64 *inSize, const 
 Z7_COM7F_IMF(CHandler::Extract(const UInt32 *indices, UInt32 numItems,
     Int32 testMode, IArchiveExtractCallback *extractCallback))
 {
+#ifndef __clang_analyzer__
+
   COM_TRY_BEGIN
 
   if (numItems == 0)
@@ -597,6 +599,8 @@ Z7_COM7F_IMF(CHandler::Extract(const UInt32 *indices, UInt32 numItems,
   return extractCallback->SetOperationResult(opResult);
 
   COM_TRY_END
+    
+#endif
 }
 
 namespace NLzmaAr {

--- a/src/CPP/7zip/Archive/SplitHandler.cpp
+++ b/src/CPP/7zip/Archive/SplitHandler.cpp
@@ -281,6 +281,8 @@ Z7_COM7F_IMF(CHandler::GetProperty(UInt32 /* index */, PROPID propID, PROPVARIAN
 Z7_COM7F_IMF(CHandler::Extract(const UInt32 *indices, UInt32 numItems,
     Int32 testMode, IArchiveExtractCallback *extractCallback))
 {
+#ifndef __clang_analyzer__
+
   COM_TRY_BEGIN
   if (numItems == 0)
     return S_OK;
@@ -319,6 +321,7 @@ Z7_COM7F_IMF(CHandler::Extract(const UInt32 *indices, UInt32 numItems,
   outStream.Release();
   return extractCallback->SetOperationResult(NExtract::NOperationResult::kOK);
   COM_TRY_END
+#endif
 }
 
 Z7_COM7F_IMF(CHandler::GetStream(UInt32 index, ISequentialInStream **stream))

--- a/src/CPP/7zip/Archive/Tar/TarHandler.cpp
+++ b/src/CPP/7zip/Archive/Tar/TarHandler.cpp
@@ -671,6 +671,7 @@ Z7_COM7F_IMF(CHandler::GetProperty(UInt32 index, PROPID propID, PROPVARIANT *val
 Z7_COM7F_IMF(CHandler::Extract(const UInt32 *indices, UInt32 numItems,
     Int32 testMode, IArchiveExtractCallback *extractCallback))
 {
+#ifndef __clang_analyzer__
   COM_TRY_BEGIN
   ISequentialInStream *stream = _seqStream;
   const bool seqMode = (_stream == NULL);
@@ -799,6 +800,7 @@ Z7_COM7F_IMF(CHandler::Extract(const UInt32 *indices, UInt32 numItems,
   }
   return S_OK;
   COM_TRY_END
+#endif
 }
 
 

--- a/src/CPP/7zip/Archive/Tar/TarUpdate.cpp
+++ b/src/CPP/7zip/Archive/Tar/TarUpdate.cpp
@@ -155,6 +155,7 @@ HRESULT UpdateArchive(IInStream *inStream, ISequentialOutStream *outStream,
     const CUpdateOptions &options,
     IArchiveUpdateCallback *updateCallback)
 {
+#ifndef __clang_analyzer__
   COutArchive outArchive;
   outArchive.Create(outStream);
   outArchive.Pos = 0;
@@ -552,6 +553,7 @@ HRESULT UpdateArchive(IInStream *inStream, ISequentialOutStream *outStream,
       }
     }
   }
+#endif
 }
 
 }}

--- a/src/CPP/7zip/Common/LimitedStreams.cpp
+++ b/src/CPP/7zip/Common/LimitedStreams.cpp
@@ -75,6 +75,7 @@ Z7_COM7F_IMF(CLimitedInStream::Seek(Int64 offset, UInt32 seekOrigin, UInt64 *new
 
 HRESULT CreateLimitedInStream(IInStream *inStream, UInt64 pos, UInt64 size, ISequentialInStream **resStream)
 {
+#ifndef __clang_analyzer__
   *resStream = NULL;
   CLimitedInStream *streamSpec = new CLimitedInStream;
   CMyComPtr<ISequentialInStream> streamTemp = streamSpec;
@@ -83,6 +84,7 @@ HRESULT CreateLimitedInStream(IInStream *inStream, UInt64 pos, UInt64 size, ISeq
   streamSpec->SeekToStart();
   *resStream = streamTemp.Detach();
   return S_OK;
+#endif
 }
 
 Z7_COM7F_IMF(CClusterInStream::Read(void *data, UInt32 size, UInt32 *processedSize))

--- a/src/CPP/7zip/Compress/CopyCoder.cpp
+++ b/src/CPP/7zip/Compress/CopyCoder.cpp
@@ -138,16 +138,20 @@ Z7_COM7F_IMF(CCopyCoder::GetInStreamProcessedSize(UInt64 *value))
 
 HRESULT CopyStream(ISequentialInStream *inStream, ISequentialOutStream *outStream, ICompressProgressInfo *progress)
 {
+#ifndef __clang_analyzer__
   CMyComPtr<ICompressCoder> copyCoder = new CCopyCoder;
   return copyCoder->Code(inStream, outStream, NULL, NULL, progress);
+#endif
 }
 
 HRESULT CopyStream_ExactSize(ISequentialInStream *inStream, ISequentialOutStream *outStream, UInt64 size, ICompressProgressInfo *progress)
 {
+#ifndef __clang_analyzer__
   NCompress::CCopyCoder *copyCoderSpec = new NCompress::CCopyCoder;
   CMyComPtr<ICompressCoder> copyCoder = copyCoderSpec;
   RINOK(copyCoder->Code(inStream, outStream, NULL, &size, progress))
   return copyCoderSpec->TotalSize == size ? S_OK : E_FAIL;
+#endif
 }
 
 }

--- a/src/CPP/Common/MyCom.h
+++ b/src/CPP/Common/MyCom.h
@@ -23,7 +23,13 @@ public:
 #endif
   CMyComPtr(T* p) throw() { if ((_p = p) != NULL) p->AddRef(); }
   CMyComPtr(const CMyComPtr<T>& lp) throw() { if ((_p = lp._p) != NULL) _p->AddRef(); }
+    
+// pastey:
+// Xcode 26.4 Static Analyzer says that here memory is used after it is freed
+// I failed to understand what the robot is trying to say us.
+#ifndef __clang_analyzer__
   ~CMyComPtr() { if (_p) _p->Release(); }
+#endif
   void Release() { if (_p) { _p->Release(); _p = NULL; } }
   operator T*() const {  return (T*)_p;  }
   // T& operator*() const {  return *_p; }

--- a/src/CPP/Windows/FileDir.cpp
+++ b/src/CPP/Windows/FileDir.cpp
@@ -1013,7 +1013,7 @@ bool GetCurrentDir(FString &path)
   }
   {
     // if (errno != ERANGE) return false;
-    #if defined(__GLIBC__) || defined(__APPLE__)
+    #if defined(__GLIBC__) || defined(__APPLE__) && !defined(__clang_analyzer__)
     /* As an extension to the POSIX.1-2001 standard, glibc's getcwd()
        allocates the buffer dynamically using malloc(3) if buf is NULL. */
     res = getcwd(NULL, 0);

--- a/src/plzma_path.cpp
+++ b/src/plzma_path.cpp
@@ -253,7 +253,10 @@ namespace plzma {
             struct dirent d, * dp;
             int readRes;
             do {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 if ( (readRes = ::readdir_r(_dir, &d, &dp)) == 0 && dp) {
+#pragma clang diagnostic pop
                     if ((::strcmp(d.d_name, ".") == 0) || (::strcmp(d.d_name, "..") == 0)) { continue; }
                     bool isDir = false, isFile = false, isLink = false;
                     rootUtf8 = nullptr;

--- a/src/plzma_path_utils.cpp
+++ b/src/plzma_path_utils.cpp
@@ -83,7 +83,10 @@ namespace pathUtils {
             struct dirent d, * dp;
             int readRes;
             do {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 if ( (readRes = ::readdir_r(dir.dir, &d, &dp)) == 0 && dp) {
+#pragma clang diagnostic pop
                     if ((::strcmp(d.d_name, ".") == 0) || (::strcmp(d.d_name, "..") == 0) || (::strlen(d.d_name) == 0)) { continue; }
                     path.append(d.d_name);
                     bool isDir = false, isFile = false, isLink = false;

--- a/swift/Path.swift
+++ b/swift/Path.swift
@@ -480,14 +480,14 @@ extension plzma_path_timestamp {
     }
 }
 
-extension plzma_path_timestamp: CustomStringConvertible {
+extension plzma_path_timestamp: @retroactive CustomStringConvertible {
     
     public var description: String {
         return "Creation: \(creationDate)\nLast access: \(lastAccessDate)\nLast modification: \(lastModificationDate)"
     }
 }
 
-extension plzma_path_timestamp: CustomDebugStringConvertible {
+extension plzma_path_timestamp: @retroactive CustomDebugStringConvertible {
     
     public var debugDescription: String {
         return self.description
@@ -512,14 +512,14 @@ extension plzma_path_stat {
     }
 }
 
-extension plzma_path_stat: CustomStringConvertible {
+extension plzma_path_stat: @retroactive CustomStringConvertible {
     
     public var description: String {
         return "Size: \(size)\n\(timestamp.description)"
     }
 }
 
-extension plzma_path_stat: CustomDebugStringConvertible {
+extension plzma_path_stat: @retroactive CustomDebugStringConvertible {
     
     public var debugDescription: String {
         return self.description


### PR DESCRIPTION
Brings `main` up to date with the `rd2-main` content captured by tag `main-pre-exp21130` (commit `554529f1`).

`main` was 12 commits behind `rd2-main` and missing the `EXP-20782` Xcode 26.4 fixes — notably the `#pragma clang diagnostic ignored "-Wdeprecated-declarations"` wrapping the `readdir_r` call in `src/plzma_path_utils.cpp`. Without that pragma, the deprecation is treated as an error and the RD2 build fails with `Command Libtool failed with a nonzero exit code`.

This is required so PLzmaSDK can be migrated from tracking `rd2-main` to `main` alongside the other RD2 dependencies.

Head branch points at the `main-pre-exp21130` tag commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)